### PR TITLE
Fix Docker build arg

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -13,7 +13,8 @@ RUN npm install
 COPY . .
 
 # Version can be overridden at build time
-ENV APP_VERSION=1.0.0
+ARG APP_VERSION=1.0.0
+ENV APP_VERSION=${APP_VERSION}
 
 # Expose the port
 EXPOSE 8080


### PR DESCRIPTION
## Summary
- use build arg `APP_VERSION` in Dockerfile so `build-and-push.sh` passes through image version

## Testing
- `npm install`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_6841ba833f848321b993bfd79442586e