### PR TITLE
Convert tutorial to Codelab

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,23 @@ The application adapts to each environment using environment variables:
 These variables are passed through the Helm chart's values files and control both functionality and appearance.
 
 In a real GitOps workflow, you would commit changes to the values files in your Git repository, and your GitOps tool (like Argo CD) would automatically apply the changes to your environments.
+
+## View the Tutorial as a Codelab
+
+The full tutorial is available in the Codelab format for easier step-by-step navigation.
+To build and serve it locally:
+
+1. Install the Codelabs `claat` tool (requires Go installed):
+   ```bash
+   go install github.com/googlecodelabs/tools/claat@latest
+   ```
+2. Export the Codelab HTML:
+   ```bash
+   ./build-codelab.sh
+   ```
+3. Serve the generated Codelab locally:
+   ```bash
+   claat serve codelabs/gitops-promotion
+   ```
+   Then open the printed URL in your browser.
+

--- a/build-codelab.sh
+++ b/build-codelab.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+CLAAT=$(command -v claat || true)
+if [ -z "$CLAAT" ]; then
+  echo "claat not found. Install with 'go install github.com/googlecodelabs/tools/claat@latest'" >&2
+  exit 1
+fi
+
+mkdir -p codelabs
+"$CLAAT" export -o codelabs tutorial/gitops_promotion_codelab.md
+
+echo "Codelab exported to codelabs/"

--- a/codelabs/gitops-promotion/codelab.json
+++ b/codelabs/gitops-promotion/codelab.json
@@ -1,0 +1,20 @@
+{
+  "environment": "web",
+  "format": "html",
+  "prefix": "https://storage.googleapis.com",
+  "mainga": "UA-49880327-14",
+  "updated": "2025-06-05T16:12:36Z",
+  "id": "gitops-promotion",
+  "duration": 0,
+  "title": "GitOps Promotion with ArgoCD and Source Hydrator Tutorial",
+  "authors": "GitOps Team",
+  "summary": "GitOps Promotion with ArgoCD and Source Hydrator",
+  "source": "tutorial/gitops_promotion_codelab.md",
+  "theme": "",
+  "status": [
+    "published"
+  ],
+  "category": null,
+  "tags": [],
+  "url": "gitops-promotion"
+}

--- a/codelabs/gitops-promotion/index.html
+++ b/codelabs/gitops-promotion/index.html
@@ -1,0 +1,784 @@
+
+<!doctype html>
+
+<html>
+<head>
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+  <meta name="theme-color" content="#4F7DC9">
+  <meta charset="UTF-8">
+  <title>GitOps Promotion with ArgoCD and Source Hydrator Tutorial</title>
+  <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Source+Code+Pro:400|Roboto:400,300,400italic,500,700|Roboto+Mono">
+  <link rel="stylesheet" href="//fonts.googleapis.com/icon?family=Material+Icons">
+  <link rel="stylesheet" href="https://storage.googleapis.com/claat-public/codelab-elements.css">
+  <style>
+    .success {
+      color: #1e8e3e;
+    }
+    .error {
+      color: red;
+    }
+  </style>
+</head>
+<body>
+  <google-codelab-analytics gaid="UA-49880327-14" ga4id=""></google-codelab-analytics>
+  <google-codelab codelab-gaid=""
+                  codelab-ga4id=""
+                  id="gitops-promotion"
+                  title="GitOps Promotion with ArgoCD and Source Hydrator Tutorial"
+                  environment="web"
+                  feedback-link="">
+    
+      <google-codelab-step label="Step 1: Introduction" duration="0">
+        <p>This tutorial demonstrates how to implement a GitOps-based promotion workflow using ArgoCD with Source Hydrator and GitOps Promoter. You&#39;ll learn how to automate the promotion of applications from development to staging to production environments while maintaining a clear change history and approval process.</p>
+<p>The demo showcases:</p>
+<ul>
+<li>Environment branch-based deployment strategy</li>
+<li>Automated synchronization between environments</li>
+<li>Separate configuration for development, staging, and production</li>
+<li>Pull request-based promotion workflow with automated checks</li>
+</ul>
+<p>By the end of this tutorial, you&#39;ll have a fully functional GitOps promotion pipeline running in your local Kubernetes cluster.</p>
+
+
+      </google-codelab-step>
+    
+      <google-codelab-step label="Step 2: Prerequisites" duration="0">
+        <p>Before starting this tutorial, ensure you have the following tools installed:</p>
+<ul>
+<li><strong>kubectl</strong> - Command-line tool for interacting with Kubernetes clusters</li>
+<li><strong>k3d</strong> or <strong>Docker Desktop with Kubernetes</strong> - For running a local Kubernetes cluster</li>
+<li><strong>GitHub Account</strong> - Required for repository hosting and GitHub App creation</li>
+<li><strong>git</strong> - Version control system</li>
+<li><strong>helm</strong> - Package manager for Kubernetes</li>
+</ul>
+<p>You&#39;ll also need an existing local Kubernetes cluster. This tutorial was tested with Docker Desktop&#39;s Kubernetes feature, but any local cluster should work.</p>
+
+
+      </google-codelab-step>
+    
+      <google-codelab-step label="Step 3: Setting up the Environment" duration="0">
+        <h2 is-upgraded>Clone the Repository</h2>
+<p>Clone the demo repository which contains all the necessary application code and Helm charts:</p>
+<pre><code language="language-bash" class="language-bash">git clone https://github.com/argoproj-labs/gitops-promotion-demo.git
+cd gitops-promotion-demo
+</code></pre>
+<h2 is-upgraded>Fork the Repository on GitHub</h2>
+<p>To work through this tutorial, you&#39;ll need your own copy of the repository on GitHub:</p>
+<ol type="1">
+<li>Go to https://github.com/argoproj-labs/gitops-promotion-demo</li>
+<li>Click the &#34;Fork&#34; button in the top right</li>
+<li>Follow the prompts to create a fork in your account</li>
+</ol>
+<p>Once forked, update your local repository to point to your fork:</p>
+<pre><code language="language-bash" class="language-bash"># Replace YOUR_GITHUB_USERNAME with your actual GitHub username
+git remote set-url origin https://github.com/YOUR_GITHUB_USERNAME/gitops-promotion-demo.git
+</code></pre>
+<p>Now you have your own copy of the repository with all the necessary application code and Helm charts ready to use.</p>
+
+
+      </google-codelab-step>
+    
+      <google-codelab-step label="Step 4: Installing Core Components" duration="0">
+        <h2 is-upgraded>Install ArgoCD with Source Hydrator</h2>
+<ol type="1">
+<li>Install ArgoCD with the Source Hydrator plugin:</li>
+</ol>
+<pre><code language="language-bash" class="language-bash"># Create argocd namespace
+kubectl create namespace argocd
+
+# Install ArgoCD with Source Hydrator
+kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install-with-hydrator.yaml
+</code></pre>
+<ol type="1" start="2">
+<li>Wait for ArgoCD pods to be ready:</li>
+</ol>
+<pre><code language="language-bash" class="language-bash">kubectl wait --for=condition=available --timeout=300s deployment/argocd-server -n argocd
+</code></pre>
+<ol type="1" start="3">
+<li>Access the ArgoCD UI:</li>
+</ol>
+<pre><code language="language-bash" class="language-bash"># Port forward the ArgoCD server
+kubectl port-forward svc/argocd-server -n argocd 8080:443
+</code></pre>
+<ol type="1" start="4">
+<li>Get the initial admin password:</li>
+</ol>
+<pre><code language="language-bash" class="language-bash"># Get the password
+kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath=&#34;{.data.password}&#34; | base64 -d
+</code></pre>
+<ol type="1" start="5">
+<li>Access the ArgoCD UI at https://localhost:8080 and log in with username <code>admin</code> and the password from the previous step.</li>
+</ol>
+<h2 is-upgraded>Install GitOps Promoter</h2>
+<ol type="1">
+<li>Install GitOps Promoter using the latest release:</li>
+</ol>
+<pre><code language="language-bash" class="language-bash">kubectl apply -f https://github.com/argoproj-labs/gitops-promoter/releases/download/v0.4.0/install.yaml
+</code></pre>
+<ol type="1" start="2">
+<li>Verify the installation:</li>
+</ol>
+<pre><code language="language-bash" class="language-bash">kubectl get pods -n promoter-system
+</code></pre>
+<p>Wait until all pods are in the <code>Running</code> state.</p>
+
+
+      </google-codelab-step>
+    
+      <google-codelab-step label="Step 5: Configuring GitOps Promoter" duration="0">
+        <h2 is-upgraded>Create a GitHub App</h2>
+<ol type="1">
+<li>Navigate to GitHub: Settings &gt; Developer settings &gt; GitHub Apps &gt; New GitHub App</li>
+<li>Fill in the following: <ul>
+<li>GitHub App name: <code>GitOps Promoter Demo</code></li>
+<li>Homepage URL: Can be your repository URL</li>
+<li>Webhook URL: Leave blank for this demo</li>
+<li>Webhook secret: Leave blank for this demo</li>
+<li>Repository permissions: <ul>
+<li>Contents: Read &amp; write</li>
+<li>Pull requests: Read &amp; write</li>
+<li>Commit statuses: Read &amp; write</li>
+</ul>
+</li>
+<li>Where can this GitHub App be installed? Choose &#34;Only on this account&#34;</li>
+</ul>
+</li>
+<li>Click &#34;Create GitHub App&#34;</li>
+<li>Note the &#34;App ID&#34; from the app page</li>
+<li>Generate a private key by clicking &#34;Generate a private key&#34; and save the downloaded file</li>
+<li>Install the app on your repository by clicking &#34;Install App&#34; and select your <code>gitops-promotion-demo</code> repository</li>
+</ol>
+<h2 is-upgraded>Create Kubernetes Secrets for GitHub App Credentials</h2>
+<p>Create a secret containing the GitHub App&#39;s private key:</p>
+<pre><code language="language-bash" class="language-bash"># Create a temporary directory for safety
+mkdir -p ~/tmp
+
+# Move the private key to this directory
+mv ~/Downloads/gitops-promoter-demo*.pem ~/tmp/gitops-promoter-demo.private-key.pem
+
+# Create the secret YAML file
+cat &gt; promoter/github-app-secret.yaml &lt;&lt; EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: github-app-credentials
+  namespace: default
+type: Opaque
+data:
+  githubAppPrivateKey: &#34;$(cat ~/tmp/gitops-promoter-demo.private-key.pem | base64 -w 0)&#34;
+EOF
+
+# Apply the secret
+kubectl apply -f promoter/github-app-secret.yaml
+</code></pre>
+<h2 is-upgraded>Create SCM Provider and GitRepository Resources</h2>
+<p>Create the necessary GitOps Promoter resources:</p>
+<pre><code language="language-bash" class="language-bash"># Create git-resources.yaml (replace with your actual App ID and GitHub username)
+cat &gt; promoter/git-resources.yaml &lt;&lt; EOF
+apiVersion: promoter.argoproj.io/v1alpha1
+kind: ScmProvider
+metadata:
+  name: github-provider
+  namespace: default
+spec:
+  type: github
+  github:
+    appID: YOUR_GITHUB_APP_ID
+    baseURL: &#34;&#34;
+  secretRef:
+    name: github-app-credentials
+---
+apiVersion: promoter.argoproj.io/v1alpha1
+kind: GitRepository
+metadata:
+  name: demo-repo
+  namespace: default
+spec:
+  url: https://github.com/YOUR_GITHUB_USERNAME/gitops-promotion-demo.git
+  scmProviderRef:
+    name: github-provider
+EOF
+
+# Update with your actual values and apply
+kubectl apply -f promoter/git-resources.yaml
+</code></pre>
+<h2 is-upgraded>Create the Promotion Strategy</h2>
+<p>Define the promotion strategy for your environments:</p>
+<pre><code language="language-bash" class="language-bash"># Create promotion-strategy.yaml
+cat &gt; promoter/promotion-strategy.yaml &lt;&lt; EOF
+apiVersion: promoter.argoproj.io/v1alpha1
+kind: PromotionStrategy
+metadata:
+  name: demo-promotion
+  namespace: default
+spec:
+  # activeCommitStatuses:
+  #   - key: argocd-app-health
+  environments:
+  - branch: environments/dev
+    autoMerge: true
+  - branch: environments/staging
+    autoMerge: true
+  - branch: environments/prod
+    autoMerge: true
+  gitRepositoryRef:
+    name: demo-repo
+EOF
+
+# Apply the promotion strategy
+kubectl apply -f promoter/promotion-strategy.yaml
+</code></pre>
+<h2 is-upgraded>Configure ArgoCD Status Reporting</h2>
+<p>Enable status reporting from ArgoCD to GitHub:</p>
+<pre><code language="language-bash" class="language-bash"># Create argocd-commitstatus.yaml
+cat &gt; promoter/argocd-commitstatus.yaml &lt;&lt; EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cm
+  namespace: argocd
+  labels:
+    app.kubernetes.io/name: argocd-cm
+    app.kubernetes.io/part-of: argocd
+data:
+  statusbadge.enabled: &#34;true&#34;
+  reposerver.commit.verification.enabled: &#34;false&#34;
+EOF
+
+# Apply the ConfigMap
+kubectl apply -f promoter/argocd-commitstatus.yaml
+</code></pre>
+
+
+      </google-codelab-step>
+    
+      <google-codelab-step label="Step 6: Preparing the Application" duration="0">
+        <h2 is-upgraded>Node.js Application Structure</h2>
+<p>Create a simple Node.js application that displays its version and environment:</p>
+<pre><code language="language-bash" class="language-bash"># Create app.js
+cat &gt; app/app.js &lt;&lt; EOF
+const express = require(&#39;express&#39;);
+const app = express();
+const port = process.env.PORT || 3000;
+
+const version = process.env.APP_VERSION || &#39;1.0.0&#39;;
+const environment = process.env.APP_ENVIRONMENT || &#39;development&#39;;
+
+// Set up a basic HTML template with environment-specific styling
+const getPageColor = () =&gt; {
+  switch(environment) {
+    case &#39;prod&#39;: return &#39;#28a745&#39;; // Green for production
+    case &#39;staging&#39;: return &#39;#ffc107&#39;; // Yellow for staging
+    case &#39;dev&#39;: return &#39;#17a2b8&#39;; // Blue for development
+    default: return &#39;#6c757d&#39;; // Grey for unknown
+  }
+};
+
+app.get(&#39;/&#39;, (req, res) =&gt; {
+  const color = getPageColor();
+  res.send(`
+    &lt;!DOCTYPE html&gt;
+    &lt;html&gt;
+    &lt;head&gt;
+      &lt;title&gt;GitOps Demo App&lt;/title&gt;
+      &lt;style&gt;
+        body {
+          font-family: Arial, sans-serif;
+          background-color: ${color};
+          color: white;
+          display: flex;
+          justify-content: center;
+          align-items: center;
+          height: 100vh;
+          margin: 0;
+        }
+        .container {
+          text-align: center;
+          background-color: rgba(0, 0, 0, 0.3);
+          padding: 40px;
+          border-radius: 8px;
+        }
+        h1 {
+          font-size: 48px;
+          margin-bottom: 10px;
+        }
+        p {
+          font-size: 24px;
+          margin: 10px 0;
+        }
+      &lt;/style&gt;
+    &lt;/head&gt;
+    &lt;body&gt;
+      &lt;div class=&#34;container&#34;&gt;
+        &lt;h1&gt;GitOps Demo App&lt;/h1&gt;
+        &lt;p&gt;Version: ${version}&lt;/p&gt;
+        &lt;p&gt;Environment: ${environment}&lt;/p&gt;
+      &lt;/div&gt;
+    &lt;/body&gt;
+    &lt;/html&gt;
+  `);
+});
+
+app.listen(port, () =&gt; {
+  console.log(\`App running on port \${port}\`);
+  console.log(\`Version: \${version}, Environment: \${environment}\`);
+});
+EOF
+</code></pre>
+<h2 is-upgraded>Dockerfile for the Application</h2>
+<p>Create a Dockerfile to containerize the application:</p>
+<pre><code language="language-bash" class="language-bash"># Create Dockerfile
+cat &gt; app/Dockerfile &lt;&lt; EOF
+FROM node:slim
+
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+ENV APP_VERSION=1.0.0
+EXPOSE 8080
+
+# Start the application
+CMD [&#34;node&#34;, &#34;app.js&#34;]
+
+EOF
+</code></pre>
+<h2 is-upgraded>Package.json</h2>
+<p>Create a package.json file for the Node.js application:</p>
+<pre><code language="language-bash" class="language-bash"># Create package.json
+cat &gt; app/package.json &lt;&lt; EOF
+{
+  &#34;name&#34;: &#34;gitops-demo-app&#34;,
+  &#34;version&#34;: &#34;1.0.0&#34;,
+  &#34;description&#34;: &#34;Simple demo app for GitOps promotion workflow&#34;,
+  &#34;main&#34;: &#34;app.js&#34;,
+  &#34;scripts&#34;: {
+    &#34;start&#34;: &#34;node app.js&#34;
+  },
+  &#34;dependencies&#34;: {
+    &#34;express&#34;: &#34;^4.17.1&#34;
+  }
+}
+EOF
+</code></pre>
+<h2 is-upgraded>Create Build and Push Script</h2>
+<p>Create a script to build and push the Docker image:</p>
+<pre><code language="language-bash" class="language-bash"># Create build-and-push.sh
+cat &gt; build-and-push.sh &lt;&lt; EOF
+#!/bin/bash
+
+# Check if a version parameter was provided
+if [ -z &#34;\$1&#34; ]; then
+  echo &#34;Usage: \$0 &lt;version&gt;&#34;
+  echo &#34;Example: \$0 1.0.0&#34;
+  exit 1
+fi
+
+VERSION=&#34;\$1&#34;
+REGISTRY=&#34;localhost:5111&#34;
+IMAGE_NAME=&#34;gitops-demo-app&#34;
+
+echo &#34;Building and pushing application image version \$VERSION...&#34;
+
+# Build the base image
+echo &#34;Building \$REGISTRY/\$IMAGE_NAME:\$VERSION&#34;
+docker build -t \$REGISTRY/\$IMAGE_NAME:\$VERSION ./app
+
+# Push the image
+echo &#34;Pushing \$REGISTRY/\$IMAGE_NAME:\$VERSION&#34;
+docker push \$REGISTRY/\$IMAGE_NAME:\$VERSION
+
+echo &#34;Done! Image is available at \$REGISTRY/\$IMAGE_NAME:\$VERSION&#34;
+EOF
+
+# Make the script executable
+chmod +x build-and-push.sh
+</code></pre>
+<p>Build the initial version of your application:</p>
+<pre><code language="language-bash" class="language-bash"># Build and push version 1.0.0
+./build-and-push.sh 1.0.0
+</code></pre>
+
+
+      </google-codelab-step>
+    
+      <google-codelab-step label="Step 7: Configuring ArgoCD Applications with Source Hydrator" duration="0">
+        <h2 is-upgraded>Create the Helm Chart</h2>
+<p>Create a Helm chart for deploying the application:</p>
+<pre><code language="language-bash" class="language-bash"># Create Chart.yaml
+cat &gt; helm-guestbook/Chart.yaml &lt;&lt; EOF
+apiVersion: v2
+name: gitops-demo
+description: A Helm chart for GitOps Promotion Demo
+type: application
+version: 0.1.0
+appVersion: &#34;1.0.0&#34;
+EOF
+
+# Create values.yaml (default values)
+cat &gt; helm-guestbook/values.yaml &lt;&lt; EOF
+replicaCount: 1
+
+image:
+  repository: localhost:5000/gitops-demo-app
+  pullPolicy: Always
+  tag: &#34;1.0.0&#34;
+
+nameOverride: &#34;&#34;
+fullnameOverride: &#34;&#34;
+
+environment: dev
+
+service:
+  type: NodePort
+  port: 80
+  targetPort: 3000
+
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 50m
+    memory: 64Mi
+EOF
+
+# Create environment-specific values files
+cat &gt; helm-guestbook/values-dev.yaml &lt;&lt; EOF
+environment: dev
+image:
+  tag: &#34;1.0.0&#34;
+EOF
+
+cat &gt; helm-guestbook/values-staging.yaml &lt;&lt; EOF
+environment: staging
+image:
+  tag: &#34;1.0.0&#34;
+EOF
+
+cat &gt; helm-guestbook/values-prod.yaml &lt;&lt; EOF
+environment: prod
+image:
+  tag: &#34;1.0.0&#34;
+EOF
+
+# Create deployment.yaml
+mkdir -p helm-guestbook/templates
+cat &gt; helm-guestbook/templates/deployment.yaml &lt;&lt; EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: &#123;&#123; include &#34;gitops-demo.fullname&#34; . }}
+  labels:
+    &#123;&#123;- include &#34;gitops-demo.labels&#34; . | nindent 4 }}
+spec:
+  replicas: &#123;&#123; .Values.replicaCount }}
+  selector:
+    matchLabels:
+      &#123;&#123;- include &#34;gitops-demo.selectorLabels&#34; . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        &#123;&#123;- include &#34;gitops-demo.selectorLabels&#34; . | nindent 8 }}
+    spec:
+      containers:
+        - name: &#123;&#123; .Chart.Name }}
+          image: &#34;&#123;&#123; .Values.image.repository }}:&#123;&#123; .Values.image.tag | default .Chart.AppVersion }}&#34;
+          imagePullPolicy: &#123;&#123; .Values.image.pullPolicy }}
+          env:
+            - name: APP_VERSION
+              value: &#34;&#123;&#123; .Values.image.tag | default .Chart.AppVersion }}&#34;
+            - name: APP_ENVIRONMENT
+              value: &#34;&#123;&#123; .Values.environment }}&#34;
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+          resources:
+            &#123;&#123;- toYaml .Values.resources | nindent 12 }}
+EOF
+
+# Create service.yaml
+cat &gt; helm-guestbook/templates/service.yaml &lt;&lt; EOF
+apiVersion: v1
+kind: Service
+metadata:
+  name: &#123;&#123; include &#34;gitops-demo.fullname&#34; . }}
+  labels:
+    &#123;&#123;- include &#34;gitops-demo.labels&#34; . | nindent 4 }}
+spec:
+  type: &#123;&#123; .Values.service.type }}
+  ports:
+    - port: &#123;&#123; .Values.service.port }}
+      targetPort: &#123;&#123; .Values.service.targetPort }}
+      protocol: TCP
+      name: http
+  selector:
+    &#123;&#123;- include &#34;gitops-demo.selectorLabels&#34; . | nindent 4 }}
+EOF
+
+# Create _helpers.tpl
+cat &gt; helm-guestbook/templates/_helpers.tpl &lt;&lt; EOF
+&#123;&#123;/*
+Expand the name of the chart.
+*/}}
+&#123;&#123;- define &#34;gitops-demo.name&#34; -}}
+&#123;&#123;- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix &#34;-&#34; }}
+&#123;&#123;- end }}
+
+&#123;&#123;/*
+Create a default fully qualified app name.
+*/}}
+&#123;&#123;- define &#34;gitops-demo.fullname&#34; -}}
+&#123;&#123;- if .Values.fullnameOverride }}
+&#123;&#123;- .Values.fullnameOverride | trunc 63 | trimSuffix &#34;-&#34; }}
+&#123;&#123;- else }}
+&#123;&#123;- \$name := default .Chart.Name .Values.nameOverride }}
+&#123;&#123;- if contains \$name .Release.Name }}
+&#123;&#123;- .Release.Name | trunc 63 | trimSuffix &#34;-&#34; }}
+&#123;&#123;- else }}
+&#123;&#123;- printf &#34;%s-%s&#34; .Release.Name \$name | trunc 63 | trimSuffix &#34;-&#34; }}
+&#123;&#123;- end }}
+&#123;&#123;- end }}
+&#123;&#123;- end }}
+
+&#123;&#123;/*
+Create chart name and version as used by the chart label.
+*/}}
+&#123;&#123;- define &#34;gitops-demo.chart&#34; -}}
+&#123;&#123;- printf &#34;%s-%s&#34; .Chart.Name .Chart.Version | replace &#34;+&#34; &#34;_&#34; | trunc 63 | trimSuffix &#34;-&#34; }}
+&#123;&#123;- end }}
+
+&#123;&#123;/*
+Common labels
+*/}}
+&#123;&#123;- define &#34;gitops-demo.labels&#34; -}}
+helm.sh/chart: &#123;&#123; include &#34;gitops-demo.chart&#34; . }}
+&#123;&#123; include &#34;gitops-demo.selectorLabels&#34; . }}
+&#123;&#123;- if .Chart.AppVersion }}
+app.kubernetes.io/version: &#123;&#123; .Chart.AppVersion | quote }}
+&#123;&#123;- end }}
+app.kubernetes.io/managed-by: &#123;&#123; .Release.Service }}
+&#123;&#123;- end }}
+
+&#123;&#123;/*
+Selector labels
+*/}}
+&#123;&#123;- define &#34;gitops-demo.selectorLabels&#34; -}}
+app.kubernetes.io/name: &#123;&#123; include &#34;gitops-demo.name&#34; . }}
+app.kubernetes.io/instance: &#123;&#123; .Release.Name }}
+&#123;&#123;- end }}
+EOF
+</code></pre>
+<h2 is-upgraded>Set up ArgoCD Source Hydrator Configuration</h2>
+<p>Create ArgoCD Source Hydrator configuration files for each environment:</p>
+<pre><code language="language-bash" class="language-bash"># Create the Source Hydrator configuration for dev
+cat &gt; helm-guestbook/.argocd-source-dev.yaml &lt;&lt; EOF
+helm:
+  parameters:
+  - name: environment
+    value: dev
+  valuesFiles:
+  - values-dev.yaml
+EOF
+
+# Create the Source Hydrator configuration for staging
+cat &gt; helm-guestbook/.argocd-source-staging.yaml &lt;&lt; EOF
+helm:
+  parameters:
+  - name: environment
+    value: staging
+  valuesFiles:
+  - values-staging.yaml
+EOF
+
+# Create the Source Hydrator configuration for prod
+cat &gt; helm-guestbook/.argocd-source-prod.yaml &lt;&lt; EOF
+helm:
+  parameters:
+  - name: environment
+    value: prod
+  valuesFiles:
+  - values-prod.yaml
+EOF
+</code></pre>
+<h2 is-upgraded>Create ArgoCD Application Manifest</h2>
+<p>Create the ApplicationSet manifest for ArgoCD:</p>
+<pre><code language="language-bash" class="language-bash"># Create namespaces for each environment
+kubectl create namespace dev
+kubectl create namespace staging
+kubectl create namespace prod
+
+# Create the ApplicationSet manifest
+cat &gt; guestbook-appset.yaml &lt;&lt; EOF
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: guestbook
+  namespace: argocd
+spec:
+  generators:
+  - list:
+      elements:
+      - name: dev
+        appName: helm-guestbook-dev
+        namespace: dev
+        hydrationPath: .argocd-source-dev.yaml
+      - name: staging
+        appName: helm-guestbook-staging
+        namespace: staging
+        hydrationPath: .argocd-source-staging.yaml
+      - name: prod
+        appName: helm-guestbook-prod
+        namespace: prod
+        hydrationPath: .argocd-source-prod.yaml
+  template:
+    metadata:
+      name: &#39;&#123;&#123;appName}}&#39;
+    spec:
+      project: default
+      source:
+        repoURL: https://github.com/YOUR_GITHUB_USERNAME/gitops-promotion-demo.git
+        targetRevision: environments/&#123;&#123;name}}
+        path: helm-guestbook
+        plugin:
+          name: argocd-lovely-plugin-source-hydrator
+          env:
+          - name: CONFIG_PATH
+            value: &#39;&#123;&#123;hydrationPath}}&#39;
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: &#39;&#123;&#123;namespace}}&#39;
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+EOF
+
+# Replace YOUR_GITHUB_USERNAME with your actual username
+# Update and apply the ApplicationSet
+kubectl apply -f guestbook-appset.yaml
+</code></pre>
+
+
+      </google-codelab-step>
+    
+      <google-codelab-step label="Step 8: Demonstrating the Promotion Workflow" duration="0">
+        <h2 is-upgraded>Initial Deployment</h2>
+<p>First, create the environment branches and push them to GitHub:</p>
+<pre><code language="language-bash" class="language-bash"># Create environment branches based on main
+git branch -f environments/dev HEAD
+git branch -f environments/staging environments/dev
+git branch -f environments/prod environments/staging
+
+# Push branches to GitHub
+git push origin environments/dev environments/staging environments/prod -f
+</code></pre>
+<p>Now verify that ArgoCD has synced the applications:</p>
+<pre><code language="language-bash" class="language-bash"># Check the ArgoCD UI or use CLI
+kubectl get applications -n argocd
+</code></pre>
+<p>Access the dev application:</p>
+<pre><code language="language-bash" class="language-bash"># Get the NodePort of the dev service
+DEV_PORT=$(kubectl get svc -n dev gitops-demo-dev-guestbook -o jsonpath=&#39;{.spec.ports[0].nodePort}&#39;)
+echo &#34;Dev application available at: http://localhost:$DEV_PORT&#34;
+</code></pre>
+<h2 is-upgraded>Promoting to Staging</h2>
+<p>To promote from dev to staging:</p>
+<pre><code language="language-bash" class="language-bash"># Push the dev branch to staging
+git push origin environments/dev:environments/staging -f
+</code></pre>
+<p>GitOps Promoter will detect this change and create a pull request (if configured that way) or directly update the staging branch. ArgoCD will then automatically sync the staging environment.</p>
+<p>Verify the staging application:</p>
+<pre><code language="language-bash" class="language-bash"># Get the NodePort of the staging service
+STAGING_PORT=$(kubectl get svc -n staging gitops-demo-staging-guestbook -o jsonpath=&#39;{.spec.ports[0].nodePort}&#39;)
+echo &#34;Staging application available at: http://localhost:$STAGING_PORT&#34;
+</code></pre>
+<h2 is-upgraded>Promoting to Production</h2>
+<p>To promote from staging to production:</p>
+<pre><code language="language-bash" class="language-bash"># Push the staging branch to production
+git push origin environments/staging:environments/prod -f
+</code></pre>
+<p>Again, GitOps Promoter will handle the change and ArgoCD will sync the production environment.</p>
+<p>Verify the production application:</p>
+<pre><code language="language-bash" class="language-bash"># Get the NodePort of the prod service
+PROD_PORT=$(kubectl get svc -n prod gitops-demo-prod-guestbook -o jsonpath=&#39;{.spec.ports[0].nodePort}&#39;)
+echo &#34;Production application available at: http://localhost:$PROD_PORT&#34;
+</code></pre>
+
+
+      </google-codelab-step>
+    
+      <google-codelab-step label="Step 9: Making a Change and Promoting" duration="0">
+        <p>Let&#39;s make a change to the application and promote it through the environments:</p>
+<ol type="1">
+<li>Update the application version:</li>
+</ol>
+<pre><code language="language-bash" class="language-bash"># Edit app/app.js to make a visible change
+# For example, change the version display or add a new feature
+
+# Build and push a new version of the application
+./build-and-push.sh 1.0.1
+</code></pre>
+<ol type="1" start="2">
+<li>Update the dev environment to use the new version:</li>
+</ol>
+<pre><code language="language-bash" class="language-bash"># Update the values-dev.yaml file to use the new image tag
+sed -i &#39;&#39; &#39;s/tag: &#34;1.0.0&#34;/tag: &#34;1.0.1&#34;/&#39; helm-guestbook/values-dev.yaml
+
+# Commit and push the changes
+git add helm-guestbook/values-dev.yaml
+git commit -m &#34;Update dev environment to version 1.0.1&#34;
+git push origin main
+
+# Update the dev environment branch
+git branch -f environments/dev HEAD
+git push origin environments/dev -f
+</code></pre>
+<ol type="1" start="3">
+<li>ArgoCD will automatically sync the dev environment with the new version. Verify in the ArgoCD UI or by accessing the application URL.</li>
+<li>Promote to staging using the same process as before:</li>
+</ol>
+<pre><code language="language-bash" class="language-bash">git push origin environments/dev:environments/staging -f
+</code></pre>
+<ol type="1" start="5">
+<li>Finally, promote to production:</li>
+</ol>
+<pre><code language="language-bash" class="language-bash">git push origin environments/staging:environments/prod -f
+</code></pre>
+
+
+      </google-codelab-step>
+    
+      <google-codelab-step label="Step 10: Conclusion and Next Steps" duration="0">
+        <p>Congratulations! You&#39;ve successfully set up a GitOps promotion workflow using ArgoCD with Source Hydrator and GitOps Promoter. This system provides:</p>
+<ul>
+<li>Automated synchronization of applications across environments</li>
+<li>Environment-specific configuration through Helm values</li>
+<li>Promotion workflow with optional approval gates</li>
+<li>Visibility into application status across environments</li>
+</ul>
+<h2 is-upgraded>Next Steps</h2>
+<p>To enhance this setup further, you could:</p>
+<ol type="1">
+<li>Add automated testing as part of the promotion process</li>
+<li>Implement canary deployments or blue/green deployments</li>
+<li>Set up notifications for successful deployments or failures</li>
+<li>Create a dashboard to visualize the status of all environments</li>
+<li>Add metrics and monitoring to track application performance</li>
+</ol>
+<p>Remember, GitOps is about more than just automating deployments—it&#39;s about ensuring consistency, reliability, and auditability across your entire infrastructure.</p>
+
+
+      </google-codelab-step>
+    
+  </google-codelab>
+
+  <script src="https://storage.googleapis.com/claat-public/native-shim.js"></script>
+  <script src="https://storage.googleapis.com/claat-public/custom-elements.min.js"></script>
+  <script src="https://storage.googleapis.com/claat-public/prettify.js"></script>
+  <script src="https://storage.googleapis.com/claat-public/codelab-elements.js"></script>
+  <script src="//support.google.com/inapp/api.js"></script>
+
+</body>
+</html>

--- a/tutorial/gitops_promotion_codelab.md
+++ b/tutorial/gitops_promotion_codelab.md
@@ -1,0 +1,816 @@
+summary: GitOps Promotion with ArgoCD and Source Hydrator
+id: gitops-promotion
+authors: GitOps Team
+status: Published
+
+# GitOps Promotion with ArgoCD and Source Hydrator Tutorial
+
+## Step 1: Introduction
+
+This tutorial demonstrates how to implement a GitOps-based promotion workflow using ArgoCD with Source Hydrator and GitOps Promoter. You'll learn how to automate the promotion of applications from development to staging to production environments while maintaining a clear change history and approval process.
+
+The demo showcases:
+- Environment branch-based deployment strategy
+- Automated synchronization between environments
+- Separate configuration for development, staging, and production
+- Pull request-based promotion workflow with automated checks
+
+By the end of this tutorial, you'll have a fully functional GitOps promotion pipeline running in your local Kubernetes cluster.
+
+## Step 2: Prerequisites
+
+Before starting this tutorial, ensure you have the following tools installed:
+
+* **kubectl** - Command-line tool for interacting with Kubernetes clusters
+* **k3d** or **Docker Desktop with Kubernetes** - For running a local Kubernetes cluster
+* **GitHub Account** - Required for repository hosting and GitHub App creation
+* **git** - Version control system
+* **helm** - Package manager for Kubernetes
+
+You'll also need an existing local Kubernetes cluster. This tutorial was tested with Docker Desktop's Kubernetes feature, but any local cluster should work.
+
+## Step 3: Setting up the Environment
+
+### Clone the Repository
+
+Clone the demo repository which contains all the necessary application code and Helm charts:
+
+```bash
+git clone https://github.com/argoproj-labs/gitops-promotion-demo.git
+cd gitops-promotion-demo
+```
+
+### Fork the Repository on GitHub
+
+To work through this tutorial, you'll need your own copy of the repository on GitHub:
+
+1. Go to https://github.com/argoproj-labs/gitops-promotion-demo
+2. Click the "Fork" button in the top right
+3. Follow the prompts to create a fork in your account
+
+Once forked, update your local repository to point to your fork:
+
+```bash
+# Replace YOUR_GITHUB_USERNAME with your actual GitHub username
+git remote set-url origin https://github.com/YOUR_GITHUB_USERNAME/gitops-promotion-demo.git
+```
+
+Now you have your own copy of the repository with all the necessary application code and Helm charts ready to use.
+
+## Step 4: Installing Core Components
+
+### Install ArgoCD with Source Hydrator
+
+1. Install ArgoCD with the Source Hydrator plugin:
+
+```bash
+# Create argocd namespace
+kubectl create namespace argocd
+
+# Install ArgoCD with Source Hydrator
+kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install-with-hydrator.yaml
+```
+
+2. Wait for ArgoCD pods to be ready:
+
+```bash
+kubectl wait --for=condition=available --timeout=300s deployment/argocd-server -n argocd
+```
+
+3. Access the ArgoCD UI:
+
+```bash
+# Port forward the ArgoCD server
+kubectl port-forward svc/argocd-server -n argocd 8080:443
+```
+
+4. Get the initial admin password:
+
+```bash
+# Get the password
+kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" | base64 -d
+```
+
+5. Access the ArgoCD UI at https://localhost:8080 and log in with username `admin` and the password from the previous step.
+
+### Install GitOps Promoter
+
+1. Install GitOps Promoter using the latest release:
+
+```bash
+kubectl apply -f https://github.com/argoproj-labs/gitops-promoter/releases/download/v0.4.0/install.yaml
+```
+
+2. Verify the installation:
+
+```bash
+kubectl get pods -n promoter-system
+```
+
+Wait until all pods are in the `Running` state.
+
+## Step 5: Configuring GitOps Promoter
+
+### Create a GitHub App
+
+1. Navigate to GitHub: Settings > Developer settings > GitHub Apps > New GitHub App
+2. Fill in the following:
+   - GitHub App name: `GitOps Promoter Demo`
+   - Homepage URL: Can be your repository URL
+   - Webhook URL: Leave blank for this demo
+   - Webhook secret: Leave blank for this demo
+   - Repository permissions:
+     - Contents: Read & write
+     - Pull requests: Read & write
+     - Commit statuses: Read & write
+   - Where can this GitHub App be installed? Choose "Only on this account"
+3. Click "Create GitHub App"
+4. Note the "App ID" from the app page
+5. Generate a private key by clicking "Generate a private key" and save the downloaded file
+6. Install the app on your repository by clicking "Install App" and select your `gitops-promotion-demo` repository
+
+### Create Kubernetes Secrets for GitHub App Credentials
+
+Create a secret containing the GitHub App's private key:
+
+```bash
+# Create a temporary directory for safety
+mkdir -p ~/tmp
+
+# Move the private key to this directory
+mv ~/Downloads/gitops-promoter-demo*.pem ~/tmp/gitops-promoter-demo.private-key.pem
+
+# Create the secret YAML file
+cat > promoter/github-app-secret.yaml << EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: github-app-credentials
+  namespace: default
+type: Opaque
+data:
+  githubAppPrivateKey: "$(cat ~/tmp/gitops-promoter-demo.private-key.pem | base64 -w 0)"
+EOF
+
+# Apply the secret
+kubectl apply -f promoter/github-app-secret.yaml
+```
+
+### Create SCM Provider and GitRepository Resources
+
+Create the necessary GitOps Promoter resources:
+
+```bash
+# Create git-resources.yaml (replace with your actual App ID and GitHub username)
+cat > promoter/git-resources.yaml << EOF
+apiVersion: promoter.argoproj.io/v1alpha1
+kind: ScmProvider
+metadata:
+  name: github-provider
+  namespace: default
+spec:
+  type: github
+  github:
+    appID: YOUR_GITHUB_APP_ID
+    baseURL: ""
+  secretRef:
+    name: github-app-credentials
+---
+apiVersion: promoter.argoproj.io/v1alpha1
+kind: GitRepository
+metadata:
+  name: demo-repo
+  namespace: default
+spec:
+  url: https://github.com/YOUR_GITHUB_USERNAME/gitops-promotion-demo.git
+  scmProviderRef:
+    name: github-provider
+EOF
+
+# Update with your actual values and apply
+kubectl apply -f promoter/git-resources.yaml
+```
+
+### Create the Promotion Strategy
+
+Define the promotion strategy for your environments:
+
+```bash
+# Create promotion-strategy.yaml
+cat > promoter/promotion-strategy.yaml << EOF
+apiVersion: promoter.argoproj.io/v1alpha1
+kind: PromotionStrategy
+metadata:
+  name: demo-promotion
+  namespace: default
+spec:
+  # activeCommitStatuses:
+  #   - key: argocd-app-health
+  environments:
+  - branch: environments/dev
+    autoMerge: true
+  - branch: environments/staging
+    autoMerge: true
+  - branch: environments/prod
+    autoMerge: true
+  gitRepositoryRef:
+    name: demo-repo
+EOF
+
+# Apply the promotion strategy
+kubectl apply -f promoter/promotion-strategy.yaml
+```
+
+### Configure ArgoCD Status Reporting
+
+Enable status reporting from ArgoCD to GitHub:
+
+```bash
+# Create argocd-commitstatus.yaml
+cat > promoter/argocd-commitstatus.yaml << EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cm
+  namespace: argocd
+  labels:
+    app.kubernetes.io/name: argocd-cm
+    app.kubernetes.io/part-of: argocd
+data:
+  statusbadge.enabled: "true"
+  reposerver.commit.verification.enabled: "false"
+EOF
+
+# Apply the ConfigMap
+kubectl apply -f promoter/argocd-commitstatus.yaml
+```
+
+## Step 6: Preparing the Application
+
+### Node.js Application Structure
+
+Create a simple Node.js application that displays its version and environment:
+
+```bash
+# Create app.js
+cat > app/app.js << EOF
+const express = require('express');
+const app = express();
+const port = process.env.PORT || 3000;
+
+const version = process.env.APP_VERSION || '1.0.0';
+const environment = process.env.APP_ENVIRONMENT || 'development';
+
+// Set up a basic HTML template with environment-specific styling
+const getPageColor = () => {
+  switch(environment) {
+    case 'prod': return '#28a745'; // Green for production
+    case 'staging': return '#ffc107'; // Yellow for staging
+    case 'dev': return '#17a2b8'; // Blue for development
+    default: return '#6c757d'; // Grey for unknown
+  }
+};
+
+app.get('/', (req, res) => {
+  const color = getPageColor();
+  res.send(`
+    <!DOCTYPE html>
+    <html>
+    <head>
+      <title>GitOps Demo App</title>
+      <style>
+        body {
+          font-family: Arial, sans-serif;
+          background-color: ${color};
+          color: white;
+          display: flex;
+          justify-content: center;
+          align-items: center;
+          height: 100vh;
+          margin: 0;
+        }
+        .container {
+          text-align: center;
+          background-color: rgba(0, 0, 0, 0.3);
+          padding: 40px;
+          border-radius: 8px;
+        }
+        h1 {
+          font-size: 48px;
+          margin-bottom: 10px;
+        }
+        p {
+          font-size: 24px;
+          margin: 10px 0;
+        }
+      </style>
+    </head>
+    <body>
+      <div class="container">
+        <h1>GitOps Demo App</h1>
+        <p>Version: ${version}</p>
+        <p>Environment: ${environment}</p>
+      </div>
+    </body>
+    </html>
+  `);
+});
+
+app.listen(port, () => {
+  console.log(\`App running on port \${port}\`);
+  console.log(\`Version: \${version}, Environment: \${environment}\`);
+});
+EOF
+```
+
+### Dockerfile for the Application
+
+Create a Dockerfile to containerize the application:
+
+```bash
+# Create Dockerfile
+cat > app/Dockerfile << EOF
+FROM node:slim
+
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+ENV APP_VERSION=1.0.0
+EXPOSE 8080
+
+# Start the application
+CMD ["node", "app.js"]
+
+EOF
+```
+
+### Package.json
+
+Create a package.json file for the Node.js application:
+
+```bash
+# Create package.json
+cat > app/package.json << EOF
+{
+  "name": "gitops-demo-app",
+  "version": "1.0.0",
+  "description": "Simple demo app for GitOps promotion workflow",
+  "main": "app.js",
+  "scripts": {
+    "start": "node app.js"
+  },
+  "dependencies": {
+    "express": "^4.17.1"
+  }
+}
+EOF
+```
+
+### Create Build and Push Script
+
+Create a script to build and push the Docker image:
+
+```bash
+# Create build-and-push.sh
+cat > build-and-push.sh << EOF
+#!/bin/bash
+
+# Check if a version parameter was provided
+if [ -z "\$1" ]; then
+  echo "Usage: \$0 <version>"
+  echo "Example: \$0 1.0.0"
+  exit 1
+fi
+
+VERSION="\$1"
+REGISTRY="localhost:5111"
+IMAGE_NAME="gitops-demo-app"
+
+echo "Building and pushing application image version \$VERSION..."
+
+# Build the base image
+echo "Building \$REGISTRY/\$IMAGE_NAME:\$VERSION"
+docker build -t \$REGISTRY/\$IMAGE_NAME:\$VERSION ./app
+
+# Push the image
+echo "Pushing \$REGISTRY/\$IMAGE_NAME:\$VERSION"
+docker push \$REGISTRY/\$IMAGE_NAME:\$VERSION
+
+echo "Done! Image is available at \$REGISTRY/\$IMAGE_NAME:\$VERSION"
+EOF
+
+# Make the script executable
+chmod +x build-and-push.sh
+```
+
+Build the initial version of your application:
+
+```bash
+# Build and push version 1.0.0
+./build-and-push.sh 1.0.0
+```
+
+## Step 7: Configuring ArgoCD Applications with Source Hydrator
+
+### Create the Helm Chart
+
+Create a Helm chart for deploying the application:
+
+```bash
+# Create Chart.yaml
+cat > helm-guestbook/Chart.yaml << EOF
+apiVersion: v2
+name: gitops-demo
+description: A Helm chart for GitOps Promotion Demo
+type: application
+version: 0.1.0
+appVersion: "1.0.0"
+EOF
+
+# Create values.yaml (default values)
+cat > helm-guestbook/values.yaml << EOF
+replicaCount: 1
+
+image:
+  repository: localhost:5000/gitops-demo-app
+  pullPolicy: Always
+  tag: "1.0.0"
+
+nameOverride: ""
+fullnameOverride: ""
+
+environment: dev
+
+service:
+  type: NodePort
+  port: 80
+  targetPort: 3000
+
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 50m
+    memory: 64Mi
+EOF
+
+# Create environment-specific values files
+cat > helm-guestbook/values-dev.yaml << EOF
+environment: dev
+image:
+  tag: "1.0.0"
+EOF
+
+cat > helm-guestbook/values-staging.yaml << EOF
+environment: staging
+image:
+  tag: "1.0.0"
+EOF
+
+cat > helm-guestbook/values-prod.yaml << EOF
+environment: prod
+image:
+  tag: "1.0.0"
+EOF
+
+# Create deployment.yaml
+mkdir -p helm-guestbook/templates
+cat > helm-guestbook/templates/deployment.yaml << EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "gitops-demo.fullname" . }}
+  labels:
+    {{- include "gitops-demo.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "gitops-demo.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "gitops-demo.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: APP_VERSION
+              value: "{{ .Values.image.tag | default .Chart.AppVersion }}"
+            - name: APP_ENVIRONMENT
+              value: "{{ .Values.environment }}"
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+EOF
+
+# Create service.yaml
+cat > helm-guestbook/templates/service.yaml << EOF
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "gitops-demo.fullname" . }}
+  labels:
+    {{- include "gitops-demo.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "gitops-demo.selectorLabels" . | nindent 4 }}
+EOF
+
+# Create _helpers.tpl
+cat > helm-guestbook/templates/_helpers.tpl << EOF
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "gitops-demo.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "gitops-demo.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- \$name := default .Chart.Name .Values.nameOverride }}
+{{- if contains \$name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name \$name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "gitops-demo.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "gitops-demo.labels" -}}
+helm.sh/chart: {{ include "gitops-demo.chart" . }}
+{{ include "gitops-demo.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "gitops-demo.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "gitops-demo.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+EOF
+```
+
+### Set up ArgoCD Source Hydrator Configuration
+
+Create ArgoCD Source Hydrator configuration files for each environment:
+
+```bash
+# Create the Source Hydrator configuration for dev
+cat > helm-guestbook/.argocd-source-dev.yaml << EOF
+helm:
+  parameters:
+  - name: environment
+    value: dev
+  valuesFiles:
+  - values-dev.yaml
+EOF
+
+# Create the Source Hydrator configuration for staging
+cat > helm-guestbook/.argocd-source-staging.yaml << EOF
+helm:
+  parameters:
+  - name: environment
+    value: staging
+  valuesFiles:
+  - values-staging.yaml
+EOF
+
+# Create the Source Hydrator configuration for prod
+cat > helm-guestbook/.argocd-source-prod.yaml << EOF
+helm:
+  parameters:
+  - name: environment
+    value: prod
+  valuesFiles:
+  - values-prod.yaml
+EOF
+```
+
+### Create ArgoCD Application Manifest
+
+Create the ApplicationSet manifest for ArgoCD:
+
+```bash
+# Create namespaces for each environment
+kubectl create namespace dev
+kubectl create namespace staging
+kubectl create namespace prod
+
+# Create the ApplicationSet manifest
+cat > guestbook-appset.yaml << EOF
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: guestbook
+  namespace: argocd
+spec:
+  generators:
+  - list:
+      elements:
+      - name: dev
+        appName: helm-guestbook-dev
+        namespace: dev
+        hydrationPath: .argocd-source-dev.yaml
+      - name: staging
+        appName: helm-guestbook-staging
+        namespace: staging
+        hydrationPath: .argocd-source-staging.yaml
+      - name: prod
+        appName: helm-guestbook-prod
+        namespace: prod
+        hydrationPath: .argocd-source-prod.yaml
+  template:
+    metadata:
+      name: '{{appName}}'
+    spec:
+      project: default
+      source:
+        repoURL: https://github.com/YOUR_GITHUB_USERNAME/gitops-promotion-demo.git
+        targetRevision: environments/{{name}}
+        path: helm-guestbook
+        plugin:
+          name: argocd-lovely-plugin-source-hydrator
+          env:
+          - name: CONFIG_PATH
+            value: '{{hydrationPath}}'
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: '{{namespace}}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+EOF
+
+# Replace YOUR_GITHUB_USERNAME with your actual username
+# Update and apply the ApplicationSet
+kubectl apply -f guestbook-appset.yaml
+```
+
+## Step 8: Demonstrating the Promotion Workflow
+
+### Initial Deployment
+
+First, create the environment branches and push them to GitHub:
+
+```bash
+# Create environment branches based on main
+git branch -f environments/dev HEAD
+git branch -f environments/staging environments/dev
+git branch -f environments/prod environments/staging
+
+# Push branches to GitHub
+git push origin environments/dev environments/staging environments/prod -f
+```
+
+Now verify that ArgoCD has synced the applications:
+
+```bash
+# Check the ArgoCD UI or use CLI
+kubectl get applications -n argocd
+```
+
+Access the dev application:
+
+```bash
+# Get the NodePort of the dev service
+DEV_PORT=$(kubectl get svc -n dev gitops-demo-dev-guestbook -o jsonpath='{.spec.ports[0].nodePort}')
+echo "Dev application available at: http://localhost:$DEV_PORT"
+```
+
+### Promoting to Staging
+
+To promote from dev to staging:
+
+```bash
+# Push the dev branch to staging
+git push origin environments/dev:environments/staging -f
+```
+
+GitOps Promoter will detect this change and create a pull request (if configured that way) or directly update the staging branch. ArgoCD will then automatically sync the staging environment.
+
+Verify the staging application:
+
+```bash
+# Get the NodePort of the staging service
+STAGING_PORT=$(kubectl get svc -n staging gitops-demo-staging-guestbook -o jsonpath='{.spec.ports[0].nodePort}')
+echo "Staging application available at: http://localhost:$STAGING_PORT"
+```
+
+### Promoting to Production
+
+To promote from staging to production:
+
+```bash
+# Push the staging branch to production
+git push origin environments/staging:environments/prod -f
+```
+
+Again, GitOps Promoter will handle the change and ArgoCD will sync the production environment.
+
+Verify the production application:
+
+```bash
+# Get the NodePort of the prod service
+PROD_PORT=$(kubectl get svc -n prod gitops-demo-prod-guestbook -o jsonpath='{.spec.ports[0].nodePort}')
+echo "Production application available at: http://localhost:$PROD_PORT"
+```
+
+## Step 9: Making a Change and Promoting
+
+Let's make a change to the application and promote it through the environments:
+
+1. Update the application version:
+
+```bash
+# Edit app/app.js to make a visible change
+# For example, change the version display or add a new feature
+
+# Build and push a new version of the application
+./build-and-push.sh 1.0.1
+```
+
+2. Update the dev environment to use the new version:
+
+```bash
+# Update the values-dev.yaml file to use the new image tag
+sed -i '' 's/tag: "1.0.0"/tag: "1.0.1"/' helm-guestbook/values-dev.yaml
+
+# Commit and push the changes
+git add helm-guestbook/values-dev.yaml
+git commit -m "Update dev environment to version 1.0.1"
+git push origin main
+
+# Update the dev environment branch
+git branch -f environments/dev HEAD
+git push origin environments/dev -f
+```
+
+3. ArgoCD will automatically sync the dev environment with the new version. Verify in the ArgoCD UI or by accessing the application URL.
+
+4. Promote to staging using the same process as before:
+
+```bash
+git push origin environments/dev:environments/staging -f
+```
+
+5. Finally, promote to production:
+
+```bash
+git push origin environments/staging:environments/prod -f
+```
+
+## Step 10: Conclusion and Next Steps
+
+Congratulations! You've successfully set up a GitOps promotion workflow using ArgoCD with Source Hydrator and GitOps Promoter. This system provides:
+
+- Automated synchronization of applications across environments
+- Environment-specific configuration through Helm values
+- Promotion workflow with optional approval gates
+- Visibility into application status across environments
+
+### Next Steps
+
+To enhance this setup further, you could:
+
+1. Add automated testing as part of the promotion process
+2. Implement canary deployments or blue/green deployments
+3. Set up notifications for successful deployments or failures
+4. Create a dashboard to visualize the status of all environments
+5. Add metrics and monitoring to track application performance
+
+Remember, GitOps is about more than just automating deployments—it's about ensuring consistency, reliability, and auditability across your entire infrastructure.


### PR DESCRIPTION
## Summary
- add codelab metadata and step headings
- add script to build the codelab
- export HTML to `codelabs/`
- document how to build and serve the codelab

## Testing
- `claat export -o codelabs tutorial/gitops_promotion_codelab.md`
- `./build-codelab.sh`


------
https://chatgpt.com/codex/tasks/task_e_6841beadf7648321bfc7af519d4aa88f